### PR TITLE
use releases path to allow a specific version to be used

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -17,7 +17,7 @@ if [ ! -f $CACHE_FILE ]; then
   IMAGE_MAGICK_VERSION="6.9.2-0"
   IMAGE_MAGICK_FILE="ImageMagick-$IMAGE_MAGICK_VERSION.tar.gz"
   IMAGE_MAGICK_DIR="ImageMagick-$IMAGE_MAGICK_VERSION"
-  IMAGE_MAGICK_URL="http://www.imagemagick.org/download/$IMAGE_MAGICK_FILE"
+  IMAGE_MAGICK_URL="http://www.imagemagick.org/download/releases/$IMAGE_MAGICK_FILE"
 
   echo "-----> Downloading ImageMagick from $IMAGE_MAGICK_URL"
   curl -L --silent $IMAGE_MAGICK_URL | tar xz


### PR DESCRIPTION
It seems that only the latest version is provided in the parent, download, path. This allows for the project to still function when a specific version is specified, as is the case in the project. It may be helpful to use the /download/ImageMagick.tar.gz file, if the desire is to use the latest version. Since I'm not familiar enough with this project and how the build packs are utilized, I leave that knowledge with the main repository owner to decide the best course of action.
