### PR TITLE
Update to use newer imagemagick, fail on dl fail.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@ heroku-buildpack-imagemagick
 =================================
 
 This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) for vendoring the ImageMagick binaries into your project.
+
+Set the version using the IMAGE_MAGICK_VERSION env var in your environment.

--- a/bin/compile
+++ b/bin/compile
@@ -7,6 +7,7 @@ indent() {
 echo "-----> Install ImageMagick"
 
 BUILD_DIR=$1
+CACHE_DIR=$2
 VENDOR_DIR="$BUILD_DIR/vendor"
 INSTALL_DIR="$VENDOR_DIR/imagemagick"
 CACHE_FILE="$CACHE_DIR/imagemagick.tar.gz"
@@ -14,13 +15,22 @@ CACHE_FILE="$CACHE_DIR/imagemagick.tar.gz"
 
 if [ ! -f $CACHE_FILE ]; then
   # install imagemagick
-  IMAGE_MAGICK_VERSION="6.9.2-0"
+  IMAGE_MAGICK_VERSION="${IMAGE_MAGICK_VERSION:-6.9.3-1}"
   IMAGE_MAGICK_FILE="ImageMagick-$IMAGE_MAGICK_VERSION.tar.gz"
   IMAGE_MAGICK_DIR="ImageMagick-$IMAGE_MAGICK_VERSION"
-  IMAGE_MAGICK_URL="http://www.imagemagick.org/download/$IMAGE_MAGICK_FILE"
+  # SSL cert used on imagemagick not recognized by heroku.
+  IMAGE_MAGICK_URL="http://www.imagemagick.org/download/releases/$IMAGE_MAGICK_FILE"
 
   echo "-----> Downloading ImageMagick from $IMAGE_MAGICK_URL"
-  curl -L --silent $IMAGE_MAGICK_URL | tar xz
+  wget $IMAGE_MAGICK_URL -P $BUILD_DIR | indent
+  
+  echo "-----> Extracting ImageMagick from $BUILD_DIR/$IMAGE_MAGICK_FILE"
+  if [ ! -f $BUILD_DIR/$IMAGE_MAGICK_FILE ]; then
+    echo "Error: Unable to download image magick" | indent
+    ls $BUILD_DIR | indent
+    exit 1;
+  fi
+  tar xvf $BUILD_DIR/$IMAGE_MAGICK_FILE | indent
 
   echo "-----> Building ImageMagick"
   cd $IMAGE_MAGICK_DIR


### PR DESCRIPTION
Also explicitly sets CACHE_DIR which fixes cache fail.

Note, this probably could use better error handling as to prevent failures from successfully building.
